### PR TITLE
ftr: 권한 분류와 ADMIN 권한의 대학원 강의 데이터베이스 초기화 api 구현

### DIFF
--- a/src/main/java/com/example/Devkor_project/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/Devkor_project/configuration/SecurityConfig.java
@@ -23,16 +23,20 @@ public class SecurityConfig
                 .cors(Customizer.withDefaults())            // CORS를 기본 값으로 활성화
 
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/api/login/**").permitAll()   // 해당 요청은 모든 사용자에게 접근 권한 허용
-                        .requestMatchers("/api/logout/**").permitAll()   // 해당 요청은 모든 사용자에게 접근 권한 허용
-                        .requestMatchers("/api/signup/**").permitAll()   // 해당 요청은 모든 사용자에게 접근 권한 허용
-                        .anyRequest().authenticated()   // 그 외의 요청은 인증된 사용자에게만 접근 권한 허용
+
+                        // 해당 요청은 모든 사용자에게 접근 권한 허용
+                        .requestMatchers("/api/**").permitAll()
+
+                        // 그 외의 요청은 인증된 사용자에게만 접근 권한 허용
+                        .anyRequest().authenticated()
+
                 )
 
                 // 필요시에 세션을 생성
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 )
+
                 .build();
     }
 }

--- a/src/main/java/com/example/Devkor_project/controller/AdminController.java
+++ b/src/main/java/com/example/Devkor_project/controller/AdminController.java
@@ -1,0 +1,56 @@
+package com.example.Devkor_project.controller;
+
+import com.example.Devkor_project.dto.LoginRequestDto;
+import com.example.Devkor_project.exception.AppException;
+import com.example.Devkor_project.exception.ErrorCode;
+import com.example.Devkor_project.service.AdminService;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@RestController
+public class AdminController
+{
+
+    @Autowired
+    AdminService adminService;
+
+    // ADMIN 권한인지 체크하는 메서드
+    void checkAuthority(HttpServletRequest request)
+    {
+        HttpSession session = request.getSession(false);
+        if(session == null)
+            throw new AppException(ErrorCode.NO_AUTHORITY, "권한이 없습니다.");
+        else if(!Objects.equals(session.getAttribute("role").toString(), "ADMIN"))
+            throw new AppException(ErrorCode.NO_AUTHORITY, "ADMIN 권한이 필요합니다.");
+    }
+
+    /*
+        < 대학원 강의 데이터베이스 초기화 컨트톨러 >
+        ADMIN 권한을 체크한 후,
+        ADMIN 권한이라면 받은 3중첩의 대학원 강의 JSON 데이터를 Entities로 변환하여 course 데이터베이스를 초기화합니다.
+    */
+    @PostMapping("/api/admin/init-course-database")
+    @JsonProperty("data")   // data JSON 객체를 MAP<String, Object> 형식으로 매핑
+    public ResponseEntity<String> initCourseDatabase(@Valid @RequestBody Map<String,Object> data,
+                                        HttpServletRequest request)
+    {
+        checkAuthority(request);
+
+        adminService.initCourseDatabase(data);
+
+        return ResponseEntity.status(HttpStatus.OK).body("대학원 강의 데이터베이스 초기화가 정상적으로 수행되었습니다.");
+    }
+}

--- a/src/main/java/com/example/Devkor_project/entity/Course.java
+++ b/src/main/java/com/example/Devkor_project/entity/Course.java
@@ -1,0 +1,27 @@
+package com.example.Devkor_project.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class Course
+{
+    @Id
+    private Long id;
+
+    @Column(nullable = false) private String graduateSchool;
+    @Column(nullable = false) private String department;
+    @Column(nullable = false) private String year;
+    @Column(nullable = false) private String semester;
+    @Column(nullable = false) private String name;
+    @Column(nullable = false) private String professor;
+    @Column(nullable = false) private String time;
+    @Column private String location;
+    @Column(nullable = false) private double rating;
+}

--- a/src/main/java/com/example/Devkor_project/entity/Profile.java
+++ b/src/main/java/com/example/Devkor_project/entity/Profile.java
@@ -23,4 +23,7 @@ public class Profile
     @Column(nullable = false) private int grade;
     @Column(nullable = false) private int semester;
     @Column(nullable = false) private String department;
+    @Column(nullable = false) private int point;
+
+    @Column(nullable = false) private String role;
 }

--- a/src/main/java/com/example/Devkor_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/Devkor_project/exception/ErrorCode.java
@@ -12,8 +12,9 @@ public enum ErrorCode
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, ""),
     INVALID_CODE(HttpStatus.UNAUTHORIZED, ""),
     UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ""),
-    EMAIL_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "");
+    EMAIL_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, ""),
+    NO_AUTHORITY(HttpStatus.UNAUTHORIZED, "");
 
-    private HttpStatus httpStatus;
-    private String message;
+    private final HttpStatus httpStatus;
+    private final String message;
 }

--- a/src/main/java/com/example/Devkor_project/repository/CodeRepository.java
+++ b/src/main/java/com/example/Devkor_project/repository/CodeRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDate;
 import java.util.Optional;
 
-public interface AuthenticationCodeRepository extends JpaRepository<Code, Long>
+public interface CodeRepository extends JpaRepository<Code, Long>
 {
     Optional<Code> findByEmail(String email);
 

--- a/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
+++ b/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
@@ -1,0 +1,8 @@
+package com.example.Devkor_project.repository;
+
+import com.example.Devkor_project.entity.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long>
+{
+}

--- a/src/main/java/com/example/Devkor_project/service/AdminService.java
+++ b/src/main/java/com/example/Devkor_project/service/AdminService.java
@@ -1,0 +1,68 @@
+package com.example.Devkor_project.service;
+
+import com.example.Devkor_project.entity.Course;
+import com.example.Devkor_project.repository.CourseRepository;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.json.JSONParser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Array;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class AdminService
+{
+    @Autowired
+    CourseRepository courseRepository;
+
+    /*
+        < 대학원 강의 데이터베이스 초기화 서비스 >
+    */
+    @Transactional
+    @SuppressWarnings("unchecked")  // Object가 Map 형식이 아닐 수도 있다는 경고 무시
+    public void initCourseDatabase(Map<String,Object> data)
+    {
+        // 데이터베이스 데이터 삭제
+        courseRepository.deleteAll();
+
+        // 데이터베이스에 데이터 추가
+        Long idIndex = 0L;
+
+        for(String graduateSchool : data.keySet())
+        {
+            Map<String,Object> value1 = (Map<String,Object>)data.get(graduateSchool);
+            for(String department : value1.keySet())
+            {
+                Map<String,Object> dataArray = (Map<String,Object>)value1.get(department);
+                List<Map<String, String>> dataList = (List<Map<String, String>>) dataArray.get("data");
+
+                for(Map<String, String> course : dataList)
+                {
+                    Course information = Course.builder()
+                            .id(idIndex)
+                            .graduateSchool(graduateSchool)
+                            .department(department)
+                            .year(course.get("year"))
+                            .semester(course.get("term"))
+                            .name(course.get("cour_nm"))
+                            .professor(course.get("prof_nm"))
+                            .time(course.get("time"))
+                            .location(course.get("time_room"))
+                            .rating(0.0)
+                            .build();
+
+                    courseRepository.save(information);
+
+                    idIndex++;
+                }
+
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/Devkor_project/service/SchedulerService.java
+++ b/src/main/java/com/example/Devkor_project/service/SchedulerService.java
@@ -1,6 +1,6 @@
 package com.example.Devkor_project.service;
 
-import com.example.Devkor_project.repository.AuthenticationCodeRepository;
+import com.example.Devkor_project.repository.CodeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +20,7 @@ import java.time.LocalDate;
 public class SchedulerService
 {
     @Autowired
-    private AuthenticationCodeRepository authenticationCodeRepository;
+    private CodeRepository codeRepository;
 
 
     @Transactional
@@ -28,6 +28,6 @@ public class SchedulerService
     @Scheduled(cron = "0 0 12 * * *")
     public void autoDeleteCode()
     {
-        authenticationCodeRepository.deleteOldCode(LocalDate.now().minusDays(1));
+        codeRepository.deleteOldCode(LocalDate.now().minusDays(1));
     }
 }


### PR DESCRIPTION
### 권한 분류

session의 권한을 USER와 ADMIN으로 나눴습니다.
일반적으로 회원가입을 할 때는 USER 권한으로 계정이 생성됩니다.
ADMIN 계정을 만드려면 데이터베이스에 직접 sql 문을 작성해야 합니다.

---
### ADMIN 전용 API

ADMIN 계정만 요청할 수 있는 api를 만들었습니다.
해당 api 요청을 보내려면, ADMIN 권한의 세션을 획득한 후, 보내야 합니다.

**대학원 강의 데이터베이스 초기화**
**POST:"/api/admin/init-course-database"**

고려대학교 대학원 수강신청 사이트에서 대학원 강의 크롤링 데이터의 내용(data.json)을 받은뒤,
1. ADMIN 세션이 요청한 경우, 대학원 강의 데이터베이스를 해당 내용으로 초기화 후, 성공 메시지(200) 응답
2. USER 세션이 요청한 경우, 실패 메시지(401) 응답
3. 세션이 존재하지 않는 경우, 실패 메시지(401) 응답