### PR TITLE
fix: 24.04.14 회의 내용 반영

### DIFF
--- a/src/main/java/com/example/Devkor_project/controller/HomeController.java
+++ b/src/main/java/com/example/Devkor_project/controller/HomeController.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.Check;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +35,7 @@ public class HomeController
     /*
         강의 검색 컨트롤러
     */
-    @PostMapping("/api/search")
+    @GetMapping("/api/search")
     public ResponseEntity<List<CourseDto>> searchCourse(@Valid @RequestBody SearchCourseRequestDto dto,
                                              HttpServletRequest request)
     {

--- a/src/main/java/com/example/Devkor_project/controller/LoginController.java
+++ b/src/main/java/com/example/Devkor_project/controller/LoginController.java
@@ -30,7 +30,7 @@ public class LoginController
         해당 이메일의 계정이 존재하지 않거나, 비밀번호가 일치하지 않는 경우: 실패 메시지(401) 응답
         예외가 발생하지 않는 경우: 세션 발행 후, 성공 메시지(200) 응답
     */
-    @PostMapping("/api/login")
+    @GetMapping("/api/login")
     public ResponseEntity<String> login(@Valid @RequestBody LoginRequestDto dto,
                                         HttpServletRequest request)
     {
@@ -84,7 +84,7 @@ public class LoginController
         해당 이메일로 발송된 인증번호가 없는 경우: 실패 메시지(500) 응답
         인증번호가 틀린 경우: 실패 메시지(401) 응답
     */
-    @PostMapping("/api/signup/email-check")
+    @GetMapping("/api/signup/email-check")
     public ResponseEntity<String> checkAuthenticationNumber(@Valid @RequestBody EmailCheckRequestDto dto)
     {
         boolean isRight = loginService.checkAuthenticationNumber(dto);
@@ -108,7 +108,5 @@ public class LoginController
         loginService.resetPassword(dto);
         return ResponseEntity.status(HttpStatus.OK).body("비밀번호가 성공적으로 초기화되었습니다.");
     }
-
-
 
 }

--- a/src/main/java/com/example/Devkor_project/dto/EmailAuthenticationRequestDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/EmailAuthenticationRequestDto.java
@@ -14,6 +14,5 @@ import lombok.ToString;
 public class EmailAuthenticationRequestDto
 {
     @NotBlank(message = "email은 빈 문자열일 수 없습니다.")
-    @Email(message = "이메일 형식이 아닙니다.")
     private String email;
 }

--- a/src/main/java/com/example/Devkor_project/dto/SearchCourseRequestDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/SearchCourseRequestDto.java
@@ -12,9 +12,6 @@ import lombok.ToString;
 @ToString
 public class SearchCourseRequestDto
 {
-    @NotBlank(message = "searchMode는 빈 문자열일 수 없습니다.")
-    private String searchMode;
-
     @NotBlank(message = "searchWord는 빈 문자열일 수 없습니다.")
     private String searchWord;
 }

--- a/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
+++ b/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
@@ -10,15 +10,6 @@ import java.util.List;
 
 public interface CourseRepository extends JpaRepository<Course, Long>
 {
-    @Query(value = "SELECT * FROM course WHERE name LIKE %:word%", nativeQuery = true)
-    List<Course> searchCourseByName(@Param("word") String word);
-
-    @Query(value = "SELECT * FROM course WHERE professor LIKE %:word%", nativeQuery = true)
-    List<Course> searchCourseByProfessor(@Param("word") String word);
-
-    @Query(value = "SELECT * FROM course WHERE course_code LIKE %:word%", nativeQuery = true)
-    List<Course> searchCourseByCourseCode(@Param("word") String word);
-
     @Query(value = "SELECT * FROM course WHERE name LIKE %:word% OR professor LIKE %:word% OR course_code LIKE %:word%", nativeQuery = true)
-    List<Course> searchCourseByAll(@Param("word") String word);
+    List<Course> searchCourse(@Param("word") String word);
 }

--- a/src/main/java/com/example/Devkor_project/service/HomeService.java
+++ b/src/main/java/com/example/Devkor_project/service/HomeService.java
@@ -29,42 +29,11 @@ public class HomeService
         if(dto.getSearchWord().length() < 2)
             throw new AppException(ErrorCode.SHORT_SEARCH_WORD, "검색어는 2글자 이상이어야 합니다.");
 
-        List<CourseDto> courses;
-
-        switch (dto.getSearchMode())
-        {
-            // 전체 검색
-            case "ALL":
-                courses = courseRepository.searchCourseByAll(dto.getSearchWord())
-                        .stream()
-                        .map(CourseDto::CourseToCousreDto)
-                        .collect(Collectors.toList());
-                break;
-            // 강의명 검색
-            case "COURSE_NAME":
-                courses = courseRepository.searchCourseByName(dto.getSearchWord())
-                        .stream()
-                        .map(CourseDto::CourseToCousreDto)
-                        .collect(Collectors.toList());
-                break;
-            // 교수명 검색
-            case "PROFESSOR":
-                courses = courseRepository.searchCourseByProfessor(dto.getSearchWord())
-                        .stream()
-                        .map(CourseDto::CourseToCousreDto)
-                        .collect(Collectors.toList());
-                break;
-            // 학수번호 검색
-            case "COURSE_CODE":
-                courses = courseRepository.searchCourseByCourseCode(dto.getSearchWord())
-                        .stream()
-                        .map(CourseDto::CourseToCousreDto)
-                        .collect(Collectors.toList());
-                break;
-            // searchMode에 잘못된 값이 들어오면 예외 발생
-            default:
-                throw new AppException(ErrorCode.UNEXPECTED_ERROR, "예기치 못한 오류가 발생하였습니다.");
-        }
+        // 강의명 + 교수명 + 학수번호 검색
+        List<CourseDto> courses = courseRepository.searchCourse(dto.getSearchWord())
+                .stream()
+                .map(CourseDto::CourseToCousreDto)
+                .collect(Collectors.toList());
 
         // 검색 결과가 없다면 예외 발생
         if(courses.isEmpty())

--- a/src/main/java/com/example/Devkor_project/service/LoginService.java
+++ b/src/main/java/com/example/Devkor_project/service/LoginService.java
@@ -32,6 +32,7 @@ public class LoginService
 {
     @Autowired
     private ProfileRepository profileRepository;
+
     @Autowired
     private CodeRepository codeRepository;
 
@@ -65,10 +66,10 @@ public class LoginService
         HttpSession session = request.getSession(true);
         session.setAttribute("email", dto.getEmail());
         session.setAttribute("role", profile.getRole());
-        if (dto.isSaved())
-            session.setMaxInactiveInterval(1800);
-        else
-            session.setMaxInactiveInterval(1800000);
+        if (dto.isSaved()) {
+            session.setMaxInactiveInterval(60 * 60 * 24 * 30);  // 30일
+        } else
+            session.setMaxInactiveInterval(60 * 60 * 24);       // 24시간
 
     }
 
@@ -140,7 +141,7 @@ public class LoginService
             context.setVariable("authenticationNumber", authenticationNumber);
 
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-            mimeMessageHelper.setTo(dto.getEmail());    // 메일 수신자
+            mimeMessageHelper.setTo(dto.getEmail() + "@korea.ac.kr");    // 메일 수신자
             mimeMessageHelper.setSubject("Academ 인증 번호");   // 메일 제목
             mimeMessageHelper.setText(templateEngine.process("sendNumber", context), true);  // 메일 내용
             javaMailSender.send(mimeMessage);


### PR DESCRIPTION
### 강의 검색 수정

강의 검색할 때, 검색 모드를 따로 지정하지 않고 전체 검색만 수행되도록, HomeService와 SearchCourseRequestDto를 수정하였습니다.

---
### 로그인 정보 저장 기간

로그인할 때, "로그인 정보 저장" 항목을 체크한다면 30일, 체크하지 않는다면 24시간 동안 세션이 유지되게끔 수정하였습니다.

---
### 고려대 이메일로 제한

고려대 이메일만 인증되게끔, 이메일 인증번호 요청 시 @ 앞의 아이디만 입력하도록 하였습니다.
따라서, 서비스에서는 해당 아이디와 "@korea.ac.kr"를 합친 이메일 주소로 인증번호를 보냅니다.

---
### GET, POST 수정

데이터베이스를 바꿀 여지가 있는 api는 POST 방식을 유지하였고, 나머지는 전부 GET 방식으로 수정하였습니다.