### PR TITLE
hotfix: security 설정 수정

### DIFF
--- a/src/main/java/com/example/Devkor_project/configuration/SecurityConfig.java
+++ b/src/main/java/com/example/Devkor_project/configuration/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.Devkor_project.configuration;
 
 import com.example.Devkor_project.service.CustomUserDetailsService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -52,8 +53,14 @@ public class SecurityConfig
         httpSecurity
                 .logout((logoutConfig) -> logoutConfig
                         .logoutUrl("/logout")
+                        .addLogoutHandler((request, response, authentication) -> {
+                            HttpSession session = request.getSession();
+                            if (session != null) {
+                                session.invalidate();
+                            }
+                        })
                         .logoutSuccessUrl("/")
-                        .deleteCookies("JSESSIONID", "remember-me")
+                        .deleteCookies("remember-me")
                 );
 
 

--- a/src/main/java/com/example/Devkor_project/dto/CustomUserDetails.java
+++ b/src/main/java/com/example/Devkor_project/dto/CustomUserDetails.java
@@ -37,7 +37,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return profile.getUsername();
+        return profile.getEmail();
     }
 
     @Override


### PR DESCRIPTION
Spring security에서는 아이디를 "username", 비밀번호를 "password" 변수명으로 사용함.
그런데 우리는 아이디가 이메일임.
따라서, CustomUserDetails 파일의 getUsername() 메서드는 username이 아닌, email을 반환해야 하므로 수정

로그아웃 시, 세션은 삭제가 안되고 remember-me만 삭제되는 문제 발생
-> security에서 세션은 직접 비활성화하고, remember-me는 deleteCookies 기능으로 삭제하도록 수정