### PR TITLE
FIX: 강의 정보 동기화 API 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Academ Back-end repository 입니다.
         │   ├── dto
         │   │   ├── CommentDto          // 강의평 관련 dto
         │   │   ├── CourseDto           // 강의 관련 dto
+        │   │   ├── CrawlingDto         // 웹 크롤링 관련 dto
         │   │   ├── ProfileDto          // 계정 관련 dto
         │   │   ├── ResponseDto         // 응답 dto
         │   │   └── TokenDto            // access token, refresh token dto

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,11 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	//Swagger
+	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// WebClient (HTTP 요청)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/Devkor_project/controller/AdminController.java
+++ b/src/main/java/com/example/Devkor_project/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.example.Devkor_project.controller;
 
 import com.example.Devkor_project.configuration.VersionProvider;
 import com.example.Devkor_project.dto.CommentDto;
+import com.example.Devkor_project.dto.CourseDto;
 import com.example.Devkor_project.dto.ResponseDto;
 import com.example.Devkor_project.dto.TrafficDto;
 import com.example.Devkor_project.service.AdminService;
@@ -54,6 +55,29 @@ public class AdminController
                                 ResponseDto.Success.builder()
                                         .message("대학원 강의 데이터베이스 추가가 정상적으로 수행되었습니다.")
                                         .data(null)
+                                        .version(versionProvider.getVersion())
+                                        .build()
+                        );
+        }
+
+        /* 강의 정보 동기화 컨트톨러 */
+        @PostMapping("/api/admin/check-course-synchronization")
+        @Operation(summary = "강의 정보 동기화")
+        @Parameters(value = {
+                @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Bearer {access token}"),
+        })
+        @ApiResponses(value = {
+                @ApiResponse(responseCode = "200", description = "CourseDto.CheckSynchronization 리스트를 반환합니다.", content = @Content(schema = @Schema(implementation = CourseDto.CheckSynchronization.class))),
+        })
+        public ResponseEntity<ResponseDto.Success> checkCourseSynchronization()
+        {
+                List<CourseDto.CheckSynchronization> data = adminService.checkCourseSynchronization();
+
+                return ResponseEntity.status(HttpStatus.OK)
+                        .body(
+                                ResponseDto.Success.builder()
+                                        .message("강의 정보 동기화를 성공적으로 수행하였습니다.")
+                                        .data(data)
                                         .version(versionProvider.getVersion())
                                         .build()
                         );

--- a/src/main/java/com/example/Devkor_project/controller/AdminController.java
+++ b/src/main/java/com/example/Devkor_project/controller/AdminController.java
@@ -1,10 +1,7 @@
 package com.example.Devkor_project.controller;
 
 import com.example.Devkor_project.configuration.VersionProvider;
-import com.example.Devkor_project.dto.CommentDto;
-import com.example.Devkor_project.dto.CourseDto;
-import com.example.Devkor_project.dto.ResponseDto;
-import com.example.Devkor_project.dto.TrafficDto;
+import com.example.Devkor_project.dto.*;
 import com.example.Devkor_project.service.AdminService;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -69,9 +66,9 @@ public class AdminController
         @ApiResponses(value = {
                 @ApiResponse(responseCode = "200", description = "CourseDto.CheckSynchronization 리스트를 반환합니다.", content = @Content(schema = @Schema(implementation = CourseDto.CheckSynchronization.class))),
         })
-        public ResponseEntity<ResponseDto.Success> checkCourseSynchronization()
+        public ResponseEntity<ResponseDto.Success> checkCourseSynchronization(@Valid @RequestBody CrawlingDto.Synchronization dto)
         {
-                List<CourseDto.CheckSynchronization> data = adminService.checkCourseSynchronization();
+                CourseDto.CheckSynchronization data = adminService.checkCourseSynchronization(dto);
 
                 return ResponseEntity.status(HttpStatus.OK)
                         .body(

--- a/src/main/java/com/example/Devkor_project/controller/AdminController.java
+++ b/src/main/java/com/example/Devkor_project/controller/AdminController.java
@@ -31,32 +31,6 @@ public class AdminController
         @Autowired AdminService adminService;
         @Autowired VersionProvider versionProvider;
 
-        /* 대학원 강의 데이터베이스 추가 컨트톨러 */
-        @PostMapping("/api/admin/insert-course-database")
-        @JsonProperty("data") // data JSON 객체를 MAP<String, Object> 형식으로 매핑
-        @Operation(summary = "대학원 강의 데이터베이스 추가")
-        @Parameters(value = {
-                @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Bearer {access token}")
-        })
-        @ApiResponses(value = {
-                @ApiResponse(responseCode = "201", description = "아무 데이터도 반환하지 않습니다."),
-                @ApiResponse(responseCode = "실패: 401 (UNAUTHORIZED)", description = "로그인하지 않은 경우", content = @Content(schema = @Schema(implementation = ResponseDto.Error.class))),
-                @ApiResponse(responseCode = "실패: 401 (LOW_AUTHORITY)", description = "권한이 부족한 경우", content = @Content(schema = @Schema(implementation = ResponseDto.Error.class))),
-                @ApiResponse(responseCode = "실패: 500 (UNEXPECTED_ERROR)", description = "예기치 못한 에러가 발생한 경우", content = @Content(schema = @Schema(implementation = ResponseDto.Error.class))),
-        })
-        public ResponseEntity<ResponseDto.Success> insertCourseDatabase(@Valid @RequestBody Map<String, Object> data) {
-                adminService.insertCourseDatabase(data);
-
-                return ResponseEntity.status(HttpStatus.CREATED)
-                        .body(
-                                ResponseDto.Success.builder()
-                                        .message("대학원 강의 데이터베이스 추가가 정상적으로 수행되었습니다.")
-                                        .data(null)
-                                        .version(versionProvider.getVersion())
-                                        .build()
-                        );
-        }
-
         /* 강의 정보 동기화 컨트톨러 */
         @PostMapping("/api/admin/check-course-synchronization")
         @Operation(summary = "강의 정보 동기화")

--- a/src/main/java/com/example/Devkor_project/dto/CourseDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CourseDto.java
@@ -271,6 +271,27 @@ public class CourseDto
         private Boolean isBookmark;
     }
 
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @ToString
+    @Builder
+    public static class CheckSynchronization
+    {
+        @NotBlank(message = "year은 빈 문자열일 수 없습니다.")
+        @Schema(description = "연도")
+        private String year;
+        @NotBlank(message = "semester은 빈 문자열일 수 없습니다.")
+        @Schema(description = "학기")
+        private String semester;
+        @NotNull(message = "count는 null일 수 없습니다.")
+        @Schema(description = "count")
+        private int count;
+        @NotNull(message = "count2는 null일 수 없습니다.")
+        @Schema(description = "count2")
+        private int count2;
+    }
+
     public static CourseDto.Basic entityToBasic(Course course, CourseRating courseRating, Boolean isBookmark) {
         return Basic.builder()
                 .course_id(course.getCourse_id())

--- a/src/main/java/com/example/Devkor_project/dto/CourseDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CourseDto.java
@@ -287,9 +287,6 @@ public class CourseDto
         @NotNull(message = "count는 null일 수 없습니다.")
         @Schema(description = "count")
         private int count;
-        @NotNull(message = "count2는 null일 수 없습니다.")
-        @Schema(description = "count2")
-        private int count2;
     }
 
     public static CourseDto.Basic entityToBasic(Course course, CourseRating courseRating, Boolean isBookmark) {

--- a/src/main/java/com/example/Devkor_project/dto/CourseDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CourseDto.java
@@ -284,9 +284,15 @@ public class CourseDto
         @NotBlank(message = "semester은 빈 문자열일 수 없습니다.")
         @Schema(description = "학기")
         private String semester;
-        @NotNull(message = "count는 null일 수 없습니다.")
-        @Schema(description = "count")
-        private int count;
+        @NotNull(message = "insert_count는 null일 수 없습니다.")
+        @Schema(description = "insert_count")
+        private int insert_count;
+        @NotNull(message = "update_count null일 수 없습니다.")
+        @Schema(description = "update_count")
+        private int update_count;
+        @NotNull(message = "delete_count null일 수 없습니다.")
+        @Schema(description = "delete_count")
+        private int delete_count;
     }
 
     public static CourseDto.Basic entityToBasic(Course course, CourseRating courseRating, Boolean isBookmark) {

--- a/src/main/java/com/example/Devkor_project/dto/CrawlingDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CrawlingDto.java
@@ -1,0 +1,119 @@
+package com.example.Devkor_project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+public class CrawlingDto
+{
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class Condition
+    {
+        @NotBlank(message = "obj는 빈 문자열일 수 없습니다.")
+        private String obj;
+        @NotBlank(message = "args는 빈 문자열일 수 없습니다.")
+        private List<String> args;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class GraduateSchool
+    {
+        @NotBlank(message = "code는 빈 문자열일 수 없습니다.")
+        private String code;
+        @NotBlank(message = "name은 빈 문자열일 수 없습니다.")
+        private String name;
+        @NotNull(message = "rowid는 null일 수 없습니다.")
+        private int rowid;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class Response_GraduateSchool
+    {
+        @NotNull(message = "data는 null일 수 없습니다.")
+        private List<CrawlingDto.GraduateSchool> data;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class Department
+    {
+        @NotBlank(message = "code는 빈 문자열일 수 없습니다.")
+        private String code;
+        @NotBlank(message = "name은 빈 문자열일 수 없습니다.")
+        private String name;
+        @NotNull(message = "rowid는 null일 수 없습니다.")
+        private int rowid;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class Response_Department
+    {
+        @NotNull(message = "data는 null일 수 없습니다.")
+        private List<CrawlingDto.Department> data;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @ToString
+    @Builder
+    public static class Course
+    {
+        private String lmt_yn;
+        private String grad_cd;
+        private String year;
+        private String wtime;
+        private String major_nm;
+        private String isu_nm;
+        private String cour_cd;
+        private String etc;
+        private String term;
+        private String flexible_school_yn;
+        private String ptime;
+        private String flexible_term;
+        private String grad_nm;
+        private String absolute_yn;
+        private String time_room;
+        private String campus;
+        private String flexible_to_dt;
+        private String lec111_cour_div;
+        private String flexible_fr_dt;
+        private String prof_nm;
+        private String cour_nm;
+        private String dept_cd;
+        private String cour_cls;
+        private String time;
+        private String exch_cor_yn;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class Response_Course
+    {
+        @NotNull(message = "data는 null일 수 없습니다.")
+        private List<CrawlingDto.Course> data;
+    }
+}

--- a/src/main/java/com/example/Devkor_project/dto/CrawlingDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CrawlingDto.java
@@ -9,6 +9,19 @@ import java.util.List;
 public class CrawlingDto
 {
     @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    public static class Synchronization
+    {
+        @NotBlank(message = "year는 빈 문자열일 수 없습니다.")
+        private String year;
+        @NotBlank(message = "semester은 빈 문자열일 수 없습니다.")
+        private String semester;
+    }
+
+    @AllArgsConstructor
     @Getter
     @Builder
     public static class Condition

--- a/src/main/java/com/example/Devkor_project/entity/Course.java
+++ b/src/main/java/com/example/Devkor_project/entity/Course.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @NoArgsConstructor
 @Getter
 @Setter
+@EqualsAndHashCode
 @ToString
 @Builder
 public class Course

--- a/src/main/java/com/example/Devkor_project/entity/Course.java
+++ b/src/main/java/com/example/Devkor_project/entity/Course.java
@@ -27,6 +27,7 @@ public class Course
 
     @Column(nullable = false) private String name;
     @Column(nullable = false) private String course_code;
+    @Column(nullable = false) private String class_number;
     @Column(nullable = false) private String professor;
     @Column(nullable = false) private String graduate_school;
     @Column(nullable = false) private String department;

--- a/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
+++ b/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
@@ -34,4 +34,17 @@ public interface CourseRepository extends JpaRepository<Course, Long>
 
     @Query(value = "SELECT count(*) FROM course WHERE name LIKE %:word% OR professor LIKE %:word% OR course_code LIKE %:word%", nativeQuery = true)
     int countCourseByKeyword(@Param("word") String word);
+
+    // 크롤링 강의 데이터와 일치하는 Course 조회
+    @Query(value = "SELECT * FROM course WHERE name = :name AND course_code = :course_code AND professor = :professor AND graduate_school = :graduate_school AND department = :department AND year = :year AND semester = :semester AND (time_location = :time_location OR (time_location IS NULL AND :time_location IS NULL))", nativeQuery = true)
+    List<Course> compareWithCrawlingData(
+            @Param("name") String name,
+            @Param("course_code") String course_code,
+            @Param("professor") String professor,
+            @Param("graduate_school") String graduate_school,
+            @Param("department") String department,
+            @Param("year") String year,
+            @Param("semester") String semester,
+            @Param("time_location") String time_location
+    );
 }

--- a/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
+++ b/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
@@ -36,16 +36,18 @@ public interface CourseRepository extends JpaRepository<Course, Long>
     int countCourseByKeyword(@Param("word") String word);
 
     // 크롤링 강의 데이터와 일치하는 Course 조회
-    @Query(value = "SELECT * FROM course WHERE name = :name AND course_code = :course_code AND class_number = :class_number AND professor = :professor AND graduate_school = :graduate_school AND department = :department AND year = :year AND semester = :semester AND (time_location = :time_location OR (time_location IS NULL AND :time_location IS NULL))", nativeQuery = true)
+    @Query(value = "SELECT * FROM course WHERE course_code = :course_code AND class_number = :class_number AND year = :year AND semester = :semester", nativeQuery = true)
     Course compareWithCrawlingData(
-            @Param("name") String name,
             @Param("course_code") String course_code,
             @Param("class_number") String class_number,
-            @Param("professor") String professor,
-            @Param("graduate_school") String graduate_school,
-            @Param("department") String department,
             @Param("year") String year,
-            @Param("semester") String semester,
-            @Param("time_location") String time_location
+            @Param("semester") String semester
+    );
+
+    // 해당 연도와 학기의 모든 Course 조회
+    @Query(value = "SELECT * FROM course WHERE year = :year AND semester = :semester", nativeQuery = true)
+    List<Course> findCourseByYearAndSemester(
+            @Param("year") String year,
+            @Param("semester") String semester
     );
 }

--- a/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
+++ b/src/main/java/com/example/Devkor_project/repository/CourseRepository.java
@@ -36,10 +36,11 @@ public interface CourseRepository extends JpaRepository<Course, Long>
     int countCourseByKeyword(@Param("word") String word);
 
     // 크롤링 강의 데이터와 일치하는 Course 조회
-    @Query(value = "SELECT * FROM course WHERE name = :name AND course_code = :course_code AND professor = :professor AND graduate_school = :graduate_school AND department = :department AND year = :year AND semester = :semester AND (time_location = :time_location OR (time_location IS NULL AND :time_location IS NULL))", nativeQuery = true)
-    List<Course> compareWithCrawlingData(
+    @Query(value = "SELECT * FROM course WHERE name = :name AND course_code = :course_code AND class_number = :class_number AND professor = :professor AND graduate_school = :graduate_school AND department = :department AND year = :year AND semester = :semester AND (time_location = :time_location OR (time_location IS NULL AND :time_location IS NULL))", nativeQuery = true)
+    Course compareWithCrawlingData(
             @Param("name") String name,
             @Param("course_code") String course_code,
+            @Param("class_number") String class_number,
             @Param("professor") String professor,
             @Param("graduate_school") String graduate_school,
             @Param("department") String department,

--- a/src/main/java/com/example/Devkor_project/service/AdminService.java
+++ b/src/main/java/com/example/Devkor_project/service/AdminService.java
@@ -36,69 +36,6 @@ public class AdminService
 
     @Autowired CourseService courseService;
 
-    /* 대학원 강의 데이터베이스 추가 서비스 */
-    @Transactional
-    @SuppressWarnings("unchecked")  // Object가 Map 형식이 아닐 수도 있다는 경고 무시
-    public void insertCourseDatabase(Map<String,Object> data)
-    {
-        for(String graduateSchool : data.keySet())
-        {
-            Map<String,Object> value1 = (Map<String,Object>)data.get(graduateSchool);
-            for(String department : value1.keySet())
-            {
-                Map<String,Object> dataArray = (Map<String,Object>)value1.get(department);
-                List<Map<String, String>> dataList = (List<Map<String, String>>) dataArray.get("data");
-
-                for(Map<String, String> courseInfo : dataList)
-                {
-                    String credit = null;
-                    String time_location = null;
-
-                    if (!courseInfo.get("time").isEmpty())
-                        credit = courseInfo.get("time").replaceAll("\\(.*?\\)", "");
-
-                    if (!courseInfo.get("time_room").isEmpty())
-                        time_location = courseInfo.get("time_room").replaceAll("<.*?>", "");
-
-                    CourseRating courseRating = CourseRating.builder()
-                            .AVG_rating(0.0)
-                            .AVG_r1_amount_of_studying(0.0)
-                            .AVG_r2_difficulty(0.0)
-                            .AVG_r3_delivery_power(0.0)
-                            .AVG_r4_grading(0.0)
-                            .COUNT_teach_t1_theory(0)
-                            .COUNT_teach_t2_practice(0)
-                            .COUNT_teach_t3_seminar(0)
-                            .COUNT_teach_t4_discussion(0)
-                            .COUNT_teach_t5_presentation(0)
-                            .COUNT_learn_t1_theory(0)
-                            .COUNT_learn_t2_thesis(0)
-                            .COUNT_learn_t3_exam(0)
-                            .COUNT_learn_t4_industry(0)
-                            .build();
-
-                    courseRatingRepository.save(courseRating);
-
-                    Course course = Course.builder()
-                            .courseRating_id(courseRating)
-                            .name(courseInfo.get("cour_nm"))
-                            .course_code(courseInfo.get("cour_cd"))
-                            .professor(courseInfo.get("prof_nm"))
-                            .graduate_school(graduateSchool)
-                            .department(department)
-                            .year(courseInfo.get("year"))
-                            .semester(courseInfo.get("term"))
-                            .credit(credit)
-                            .time_location(time_location)
-                            .COUNT_comments(0)
-                            .build();
-
-                    courseRepository.save(course);
-                }
-            }
-        }
-    }
-
     /* 강의 정보 동기화 서비스 */
     @Transactional
     public CourseDto.CheckSynchronization checkCourseSynchronization(CrawlingDto.Synchronization dto)

--- a/src/main/java/com/example/Devkor_project/service/AdminService.java
+++ b/src/main/java/com/example/Devkor_project/service/AdminService.java
@@ -100,120 +100,105 @@ public class AdminService
     }
 
     /* 강의 정보 동기화 서비스 */
-    public List<CourseDto.CheckSynchronization> checkCourseSynchronization()
+    @Transactional
+    public CourseDto.CheckSynchronization checkCourseSynchronization(CrawlingDto.Synchronization dto)
     {
-        // 최종 결과를 담을 변수
-        List<CourseDto.CheckSynchronization> result = new ArrayList<>();
+        WebClient webClient = WebClient.builder().build();  // HTTP 요청을 보내기 위한 WebClient 인스턴스
+        ObjectMapper objectMapper = new ObjectMapper();     // 문자열을 dto로 변환하기 위한 ObjectMapper
+        int count = 0;      // 동기화 되지 않은 강의 개수
 
-        // 확인할 연도와 학기
-        List<String> years = List.of("2020", "2021", "2022", "2023", "2024");
-        List<String> semesters = List.of("1R", "1S", "2R", "2W", "M0", "M1", "M2", "M3", "M4", "M5", "M6", "M7");
+        // 대학원 리스트를 요청한 후, 응답을 문자열로 저장
+        String response = webClient.post()
+                .uri("https://sugang.korea.ac.kr/view?attribute=combo&fake=1712483560986")
+                .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+                .header("Referer", "https://sugang.korea.ac.kr/graduate/core?attribute=coreMain&flagx=X&fake=1712483556643")
+                .accept(MediaType.APPLICATION_JSON)
+                .body(BodyInserters.fromFormData("obj", "pColCd")
+                        .with("args", "KOR")
+                        .with("args", dto.getYear())
+                        .with("args", dto.getSemester())
+                        .with("args", "1"))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
 
-        for(String year:years)
-        {
-            for(String semester:semesters)
+        try {
+            // 대학원 리스트 응답 문자열을 dto로 변환
+            CrawlingDto.Response_GraduateSchool response_graduateSchool = objectMapper.readValue(response, CrawlingDto.Response_GraduateSchool.class);
+            List<CrawlingDto.GraduateSchool> graduateSchools = response_graduateSchool.getData();
+
+            for(CrawlingDto.GraduateSchool graduateSchool:graduateSchools)
             {
-                if(Objects.equals(year, "2024") && Objects.equals(semester, "2W"))
-                {
-                    continue;
-                }
-
-                WebClient webClient = WebClient.builder().build();  // HTTP 요청을 보내기 위한 WebClient 인스턴스
-                ObjectMapper objectMapper = new ObjectMapper();     // 문자열을 dto로 변환하기 위한 ObjectMapper
-                int count = 0;      // 동기화 되지 않은 강의 개수
-                int count2 = 0;     // 정보가 완전히 겹치는 강의 정보 개수
-
-                // 대학원 리스트를 요청한 후, 응답을 문자열로 저장
-                String response = webClient.post()
+                // 학과 리스트를 요청한 후, 응답을 문자열로 저장
+                response = webClient.post()
                         .uri("https://sugang.korea.ac.kr/view?attribute=combo&fake=1712483560986")
                         .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
                         .header("Referer", "https://sugang.korea.ac.kr/graduate/core?attribute=coreMain&flagx=X&fake=1712483556643")
                         .accept(MediaType.APPLICATION_JSON)
-                        .body(BodyInserters.fromFormData("obj", "pColCd")
+                        .body(BodyInserters.fromFormData("obj", "pDeptCd")
                                 .with("args", "KOR")
-                                .with("args", year)
-                                .with("args", semester)
+                                .with("args", dto.getYear())
+                                .with("args", dto.getSemester())
+                                .with("args", graduateSchool.getCode())
                                 .with("args", "1"))
                         .retrieve()
                         .bodyToMono(String.class)
                         .block();
 
                 try {
-                    // 대학원 리스트 응답 문자열을 dto로 변환
-                    CrawlingDto.Response_GraduateSchool response_graduateSchool = objectMapper.readValue(response, CrawlingDto.Response_GraduateSchool.class);
-                    List<CrawlingDto.GraduateSchool> graduateSchools = response_graduateSchool.getData();
+                    // 학과 리스트 응답 문자열을 dto로 변환
+                    CrawlingDto.Response_Department response_department = objectMapper.readValue(response, CrawlingDto.Response_Department.class);
+                    List<CrawlingDto.Department> departments = response_department.getData();
 
-                    for(CrawlingDto.GraduateSchool graduateSchool:graduateSchools)
+                    for(CrawlingDto.Department department:departments)
                     {
-                        // 학과 리스트를 요청한 후, 응답을 문자열로 저장
+                        // 강의 리스트를 요청한 후, 응답을 문자열로 저장
                         response = webClient.post()
-                                .uri("https://sugang.korea.ac.kr/view?attribute=combo&fake=1712483560986")
+                                .uri("https://sugang.korea.ac.kr/graduate/view?attribute=lectGradData&fake=1712483595039")
                                 .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
                                 .header("Referer", "https://sugang.korea.ac.kr/graduate/core?attribute=coreMain&flagx=X&fake=1712483556643")
                                 .accept(MediaType.APPLICATION_JSON)
-                                .body(BodyInserters.fromFormData("obj", "pDeptCd")
-                                        .with("args", "KOR")
-                                        .with("args", year)
-                                        .with("args", semester)
-                                        .with("args", graduateSchool.getCode())
-                                        .with("args", "1"))
+                                .body(BodyInserters.fromFormData("pYear", dto.getYear())
+                                        .with("pTerm", dto.getSemester())
+                                        .with("pCampus", "1")
+                                        .with("pColCd", graduateSchool.getCode())
+                                        .with("pDeptCd", department.getCode()))
                                 .retrieve()
                                 .bodyToMono(String.class)
                                 .block();
 
                         try {
-                            // 학과 리스트 응답 문자열을 dto로 변환
-                            CrawlingDto.Response_Department response_department = objectMapper.readValue(response, CrawlingDto.Response_Department.class);
-                            List<CrawlingDto.Department> departments = response_department.getData();
+                            // 강의 리스트 응답 문자열을 dto로 변환
+                            CrawlingDto.Response_Course response_course = objectMapper.readValue(response, CrawlingDto.Response_Course.class);
+                            List<CrawlingDto.Course> courses = response_course.getData();
 
-                            for(CrawlingDto.Department department:departments)
+                            for(CrawlingDto.Course course:courses)
                             {
-                                // 강의 리스트를 요청한 후, 응답을 문자열로 저장
-                                response = webClient.post()
-                                        .uri("https://sugang.korea.ac.kr/graduate/view?attribute=lectGradData&fake=1712483595039")
-                                        .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
-                                        .header("Referer", "https://sugang.korea.ac.kr/graduate/core?attribute=coreMain&flagx=X&fake=1712483556643")
-                                        .accept(MediaType.APPLICATION_JSON)
-                                        .body(BodyInserters.fromFormData("pYear", year)
-                                                .with("pTerm", semester)
-                                                .with("pCampus", "1")
-                                                .with("pColCd", graduateSchool.getCode())
-                                                .with("pDeptCd", department.getCode()))
-                                        .retrieve()
-                                        .bodyToMono(String.class)
-                                        .block();
+                                count++;
 
-                                try {
-                                    // 강의 리스트 응답 문자열을 dto로 변환
-                                    CrawlingDto.Response_Course response_course = objectMapper.readValue(response, CrawlingDto.Response_Course.class);
-                                    List<CrawlingDto.Course> courses = response_course.getData();
+                                // 해당 크롤링 강의 데이터와 일치하는 데이터를 데이터베이스에서 조회
+                                List<Course> coursesInDatabase = courseRepository.compareWithCrawlingData(
+                                        course.getCour_nm(),
+                                        course.getCour_cd(),
+                                        course.getProf_nm(),
+                                        graduateSchool.getName(),
+                                        department.getName(),
+                                        dto.getYear(),
+                                        dto.getSemester(),
+                                        course.getTime_room().isEmpty() ? null : course.getTime_room().replaceAll("<.*?>", "")
+                                );
 
-                                    for(CrawlingDto.Course course:courses)
+                                if(!coursesInDatabase.isEmpty())
+                                {
+                                    for(Course courseInDatabase:coursesInDatabase)
                                     {
-                                        // 해당 크롤링 강의 데이터와 일치하는 데이터를 데이터베이스에서 조회
-                                        List<Course> coursesInDatabase = courseRepository.compareWithCrawlingData(
-                                                course.getCour_nm(),
-                                                course.getCour_cd(),
-                                                course.getProf_nm(),
-                                                graduateSchool.getName(),
-                                                department.getName(),
-                                                year,
-                                                semester,
-                                                course.getTime_room().isEmpty() ? null : course.getTime_room().replaceAll("<.*?>", "")
-                                        );
-
-                                        if(coursesInDatabase.isEmpty())
+                                        if(Objects.equals(courseInDatabase.getClass_number(), "abcd"))
                                         {
-                                            log.info(course.toString());
-                                            count++;
-                                        }
-                                        else if(coursesInDatabase.size() >= 2)
-                                        {
-                                            count2++;
+                                            courseInDatabase.setClass_number(course.getCour_cls());
+                                            courseRepository.save(courseInDatabase);
+                                            break;
                                         }
                                     }
-                                } catch (Exception error) {
-                                    throw new RuntimeException(error);
                                 }
                             }
                         } catch (Exception error) {
@@ -223,22 +208,16 @@ public class AdminService
                 } catch (Exception error) {
                     throw new RuntimeException(error);
                 }
-
-                log.info(String.valueOf(count));
-                log.info(String.valueOf(count2));
-
-                result.add(
-                        CourseDto.CheckSynchronization.builder()
-                                .year(year)
-                                .semester(semester)
-                                .count(count)
-                                .count2(count2)
-                                .build()
-                );
             }
+        } catch (Exception error) {
+            throw new RuntimeException(error);
         }
 
-        return result;
+        return CourseDto.CheckSynchronization.builder()
+                .year(dto.getYear())
+                .semester(dto.getSemester())
+                .count(count)
+                .build();
     }
 
     /* 강의평 신고 내역 조회 서비스 */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,12 +16,8 @@ spring:
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
-    show-sql: true
     hibernate:
       ddl-auto: update # update 수정 필요
-    properties:
-      hibernate:
-        format_sql: true  # JPA 로그 이쁘게 구조화
 
   ## Google SMTP server
   mail:
@@ -42,16 +38,6 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
-
-## JPA 로깅 설정
-logging:
-  level:
-    org:
-      hibernate:
-        SQL: debug        # 디버그 레벨로 쿼리 출력
-        orm:
-          jdbc:
-            bind: trace   # 쿼리의 파라미터 출력
 
 ## JWT 설정
 jwt:


### PR DESCRIPTION
강의 정보 동기화 API 구현해놓았습니다. ( /api/admin/check-course-synchronization )
해당 api의 컨트롤러와 서비스는 각각 AdminController, AdminService에 위치합니다.

**해당 api를 만든 이유**

기존에는 외부 파이썬 프로그램을 통해 크롤링한 데이터 파일로 "대학원 강의 데이터베이스 추가 api"를 호출하는 형태로 강의 데이터베이스를 추가하였습니다.
그러나, 이렇게 구현하니 고려대학교 대학원 수강신청 페이지에 새로 추가되거나, 수정되는 강의 정보를 동기화할 수 없었습니다.
따라서, 대학원 강의 데이터베이스 추가( /api/admin/insert-course-database ) api를 삭제하고, 강의 정보 동기화( /api/admin/check-course-synchronization ) api를 추가하였습니다.

**동작 원리**

해당 api는 연도와 학기를 요청으로 받습니다.
api를 요청하면 서비스는 고려대학교 대학원 수강신청 사이트에서 해당 연도와 학기에 해당하는 대학원 리스트를 불러옵니다.
그리고, 각각의 대학원에 대한 학과 리스트를 불러옵니다.
그리고, 각각의 학과에 대한 강의 리스트를 불러옵니다.
( 즉, 3중 for문 )
이렇게 해서 해당 연도와 학기에 대한 모든 강의 정보를 불러왔다면, 현재 데이터베이스에 존재하는 강의 데이터와 비교합니다.
- 먼저, 현재 데이터베이스에 해당 강의 정보가 존재하는지 확인합니다. 연도, 학기, 학수번호, 분반으로 데이터를 찾습니다.
- 만약, 데이터가 존재하지 않는다면, 해당 강의 정보를 데이터베이스에 추가합니다. ( 해당 강의에 대한 강의 평점 엔티티도 추가 )
그리고, insert_count를 1 증가시킵니다.
- 만약, 데이터가 존재한다면, 해당 강의 정보와 데이터베이스의 정보가 동일한지 확인합니다.
동일하지 않다면, 데이터베이스의 해당 강의 엔티티를 수정하고 update_count를 1 증가시킵니다.
- 크롤링해온 모든 강의 정보를 확인헀는데, 데이터베이스에 아직 확인이 안된 해당 연도와 학기의 엔티티가 남아있다면, 전부 데이터베이스에서 삭제합니다. ( 해당 강의에 대한 강의 평점 엔티티도 삭제 )
그리고, 삭제한 개수만큼 delete_count를 증가시킵니다.

처리가 모두 끝나면 추가된 강의 정보 개수, 수정된 강의 정보 개수, 삭제된 강의 정보 개수를 확인할 수 있는 것입니다.

**버그 수정**

심각한 버그가 있어서 어쩔 수 없이 main에 미리 푸시해놓은 사항입니다.
지금까지 강의 엔티티에서는 분반 정보가 존재하지 않았습니다.
그러다보니, 모든 정보가 일치하는 강의 엔티티들이 존재했습니다.
따라서, Course 테이블에 분반을 담을 class_number 컬럼을 추가하였습니다.

**추가 조치**

서버는 스프링부트에서 출력하는 로그를 전부 저장합니다.
따라서, 로그를 출력하는 코드를 삭제해놓았어야 했는데, 쿼리문 로그를 출력하는 설정이 application.yml 파일에 남아있었습니다.
따라서, 이제 더이상 로그를 출력하지 않게끔 해당 부분을 제거하였습니다.