### PR TITLE
v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Academ Back-end repository 입니다.
 ---
 
 ### 프로젝트 구조
-( 최신화 : v1.1.1 )
+( 최신화 : v1.1.2 )
 ```
 │
 ├── .github

--- a/src/main/java/com/example/Devkor_project/controller/AdminController.java
+++ b/src/main/java/com/example/Devkor_project/controller/AdminController.java
@@ -31,32 +31,6 @@ public class AdminController
         @Autowired AdminService adminService;
         @Autowired VersionProvider versionProvider;
 
-        /* 대학원 강의 데이터베이스 추가 컨트톨러 */
-        @PostMapping("/api/admin/insert-course-database")
-        @JsonProperty("data") // data JSON 객체를 MAP<String, Object> 형식으로 매핑
-        @Operation(summary = "대학원 강의 데이터베이스 추가")
-        @Parameters(value = {
-                @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Bearer {access token}")
-        })
-        @ApiResponses(value = {
-                @ApiResponse(responseCode = "201", description = "아무 데이터도 반환하지 않습니다."),
-                @ApiResponse(responseCode = "실패: 401 (UNAUTHORIZED)", description = "로그인하지 않은 경우", content = @Content(schema = @Schema(implementation = ResponseDto.Error.class))),
-                @ApiResponse(responseCode = "실패: 401 (LOW_AUTHORITY)", description = "권한이 부족한 경우", content = @Content(schema = @Schema(implementation = ResponseDto.Error.class))),
-                @ApiResponse(responseCode = "실패: 500 (UNEXPECTED_ERROR)", description = "예기치 못한 에러가 발생한 경우", content = @Content(schema = @Schema(implementation = ResponseDto.Error.class))),
-        })
-        public ResponseEntity<ResponseDto.Success> insertCourseDatabase(@Valid @RequestBody Map<String, Object> data) {
-                adminService.insertCourseDatabase(data);
-
-                return ResponseEntity.status(HttpStatus.CREATED)
-                        .body(
-                                ResponseDto.Success.builder()
-                                        .message("대학원 강의 데이터베이스 추가가 정상적으로 수행되었습니다.")
-                                        .data(null)
-                                        .version(versionProvider.getVersion())
-                                        .build()
-                        );
-        }
-
         /* 강의 정보 동기화 컨트톨러 */
         @PostMapping("/api/admin/check-course-synchronization")
         @Operation(summary = "강의 정보 동기화")

--- a/src/main/java/com/example/Devkor_project/controller/AdminController.java
+++ b/src/main/java/com/example/Devkor_project/controller/AdminController.java
@@ -32,7 +32,7 @@ public class AdminController
         @Autowired VersionProvider versionProvider;
 
         /* 강의 정보 동기화 컨트톨러 */
-        @PostMapping("/api/admin/check-course-synchronization")
+        @PostMapping("/api/admin/course-synchronization")
         @Operation(summary = "강의 정보 동기화")
         @Parameters(value = {
                 @Parameter(in = ParameterIn.HEADER, name = "Authorization", description = "Bearer {access token}"),

--- a/src/main/java/com/example/Devkor_project/dto/CommentDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CommentDto.java
@@ -244,6 +244,9 @@ public class CommentDto
         @NotBlank(message = "course_code는 빈 문자열일 수 없습니다.")
         @Schema(description = "학수번호")
         private String course_code;
+        @NotBlank(message = "class_number는 빈 문자열일 수 없습니다.")
+        @Schema(description = "분반")
+        private String class_number;
         @NotBlank(message = "graduate_school은 빈 문자열일 수 없습니다.")
         @Schema(description = "대학원")
         private String graduate_school;
@@ -539,6 +542,9 @@ public class CommentDto
         @NotBlank(message = "course_code는 빈 문자열일 수 없습니다.")
         @Schema(description = "학수번호")
         private String course_code;
+        @NotBlank(message = "class_number는 빈 문자열일 수 없습니다.")
+        @Schema(description = "분반")
+        private String class_number;
         @NotBlank(message = "graduate_school은 빈 문자열일 수 없습니다.")
         @Schema(description = "대학원")
         private String graduate_school;
@@ -628,9 +634,10 @@ public class CommentDto
                                                              com.example.Devkor_project.entity.Comment comment,
                                                              CommentRating commentRating)
     {
-        return CommentDto.StartUpdate.builder()
+        return StartUpdate.builder()
                 .course_id(course.getCourse_id())
                 .course_code(course.getCourse_code())
+                .class_number(course.getClass_number())
                 .graduate_school(course.getGraduate_school())
                 .department(course.getDepartment())
                 .year(course.getYear())
@@ -681,6 +688,7 @@ public class CommentDto
                 .comment_id(comment.getComment_id())
                 .course_id(course.getCourse_id())
                 .course_code(course.getCourse_code())
+                .class_number(course.getClass_number())
                 .graduate_school(course.getGraduate_school())
                 .department(course.getDepartment())
                 .year(course.getYear())

--- a/src/main/java/com/example/Devkor_project/dto/CourseDto.java
+++ b/src/main/java/com/example/Devkor_project/dto/CourseDto.java
@@ -25,6 +25,9 @@ public class CourseDto
         @NotBlank(message = "course_code는 빈 문자열일 수 없습니다.")
         @Schema(description = "학수번호")
         private String course_code;
+        @NotBlank(message = "class_number는 빈 문자열일 수 없습니다.")
+        @Schema(description = "분반")
+        private String class_number;
         @NotBlank(message = "graduate_school은 빈 문자열일 수 없습니다.")
         @Schema(description = "대학원")
         private String graduate_school;
@@ -111,6 +114,9 @@ public class CourseDto
         @NotBlank(message = "course_code는 빈 문자열일 수 없습니다.")
         @Schema(description = "학수번호")
         private String course_code;
+        @NotBlank(message = "class_number는 빈 문자열일 수 없습니다.")
+        @Schema(description = "분반")
+        private String class_number;
         @NotBlank(message = "graduate_school은 빈 문자열일 수 없습니다.")
         @Schema(description = "대학원")
         private String graduate_school;
@@ -153,6 +159,9 @@ public class CourseDto
         @NotBlank(message = "course_code는 빈 문자열일 수 없습니다.")
         @Schema(description = "학수번호")
         private String course_code;
+        @NotBlank(message = "class_number는 빈 문자열일 수 없습니다.")
+        @Schema(description = "분반")
+        private String class_number;
         @NotBlank(message = "graduate_school은 빈 문자열일 수 없습니다.")
         @Schema(description = "대학원")
         private String graduate_school;
@@ -242,6 +251,9 @@ public class CourseDto
         @NotBlank(message = "course_code는 빈 문자열일 수 없습니다.")
         @Schema(description = "학수번호")
         private String course_code;
+        @NotBlank(message = "class_number는 빈 문자열일 수 없습니다.")
+        @Schema(description = "분반")
+        private String class_number;
         @NotBlank(message = "graduate_school은 빈 문자열일 수 없습니다.")
         @Schema(description = "대학원")
         private String graduate_school;
@@ -299,6 +311,7 @@ public class CourseDto
         return Basic.builder()
                 .course_id(course.getCourse_id())
                 .course_code(course.getCourse_code())
+                .class_number(course.getClass_number())
                 .graduate_school(course.getGraduate_school())
                 .department(course.getDepartment())
                 .year(course.getYear())
@@ -330,6 +343,7 @@ public class CourseDto
         return ExpiredBasic.builder()
                 .course_id(course.getCourse_id())
                 .course_code(course.getCourse_code())
+                .class_number(course.getClass_number())
                 .graduate_school(course.getGraduate_school())
                 .department(course.getDepartment())
                 .year(course.getYear())
@@ -351,6 +365,7 @@ public class CourseDto
         return Detail.builder()
                 .course_id(course.getCourse_id())
                 .course_code(course.getCourse_code())
+                .class_number(course.getClass_number())
                 .graduate_school(course.getGraduate_school())
                 .department(course.getDepartment())
                 .year(course.getYear())
@@ -385,6 +400,7 @@ public class CourseDto
         return ExpiredDetail.builder()
                 .course_id(course.getCourse_id())
                 .course_code(course.getCourse_code())
+                .class_number(course.getClass_number())
                 .graduate_school(course.getGraduate_school())
                 .department(course.getDepartment())
                 .year(course.getYear())

--- a/src/main/java/com/example/Devkor_project/service/AdminService.java
+++ b/src/main/java/com/example/Devkor_project/service/AdminService.java
@@ -36,69 +36,6 @@ public class AdminService
 
     @Autowired CourseService courseService;
 
-    /* 대학원 강의 데이터베이스 추가 서비스 */
-    @Transactional
-    @SuppressWarnings("unchecked")  // Object가 Map 형식이 아닐 수도 있다는 경고 무시
-    public void insertCourseDatabase(Map<String,Object> data)
-    {
-        for(String graduateSchool : data.keySet())
-        {
-            Map<String,Object> value1 = (Map<String,Object>)data.get(graduateSchool);
-            for(String department : value1.keySet())
-            {
-                Map<String,Object> dataArray = (Map<String,Object>)value1.get(department);
-                List<Map<String, String>> dataList = (List<Map<String, String>>) dataArray.get("data");
-
-                for(Map<String, String> courseInfo : dataList)
-                {
-                    String credit = null;
-                    String time_location = null;
-
-                    if (!courseInfo.get("time").isEmpty())
-                        credit = courseInfo.get("time").replaceAll("\\(.*?\\)", "");
-
-                    if (!courseInfo.get("time_room").isEmpty())
-                        time_location = courseInfo.get("time_room").replaceAll("<.*?>", "");
-
-                    CourseRating courseRating = CourseRating.builder()
-                            .AVG_rating(0.0)
-                            .AVG_r1_amount_of_studying(0.0)
-                            .AVG_r2_difficulty(0.0)
-                            .AVG_r3_delivery_power(0.0)
-                            .AVG_r4_grading(0.0)
-                            .COUNT_teach_t1_theory(0)
-                            .COUNT_teach_t2_practice(0)
-                            .COUNT_teach_t3_seminar(0)
-                            .COUNT_teach_t4_discussion(0)
-                            .COUNT_teach_t5_presentation(0)
-                            .COUNT_learn_t1_theory(0)
-                            .COUNT_learn_t2_thesis(0)
-                            .COUNT_learn_t3_exam(0)
-                            .COUNT_learn_t4_industry(0)
-                            .build();
-
-                    courseRatingRepository.save(courseRating);
-
-                    Course course = Course.builder()
-                            .courseRating_id(courseRating)
-                            .name(courseInfo.get("cour_nm"))
-                            .course_code(courseInfo.get("cour_cd"))
-                            .professor(courseInfo.get("prof_nm"))
-                            .graduate_school(graduateSchool)
-                            .department(department)
-                            .year(courseInfo.get("year"))
-                            .semester(courseInfo.get("term"))
-                            .credit(credit)
-                            .time_location(time_location)
-                            .COUNT_comments(0)
-                            .build();
-
-                    courseRepository.save(course);
-                }
-            }
-        }
-    }
-
     /* 강의 정보 동기화 서비스 */
     @Transactional
     public CourseDto.CheckSynchronization checkCourseSynchronization(CrawlingDto.Synchronization dto)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 academ:
-  version: "v1.1.1"
+  version: "v1.1.2"
 
 spring:
 


### PR DESCRIPTION
### 1. Course 테이블에 class_number 컬럼 추가
강의 테이블에 분반 정보를 추가하였습니다!
### 2. 분반 정보를 반환하게 된 api 목록
이제 다음 api들이 분반 정보를 추가적으로 반환하게 되었습니다.
분반은 "class_number" 변수에 담겨 있습니다.

- 강의 검색 ( /api/course/search )
- 강의 상세 정보 ( /api/course/detail )
- 강의평 작성 시작 ( /api/course/start-insert-comment )
- 강의평 수정 시작 ( /api/course/start-update-comment )
- 내가 작성한 강의평 정보 조회 ( /api/mypage/my-comments )
- 내가 북마크한 강의 정보 조회 ( /api/mypage/my-bookmarks )

### 3. 강의 정보 동기화 방식 수정
**기존에 강의 정보를 동기화하던 방법** : 고려대 대학원 수강신청 사이트로부터 외부 파이썬 코드로 강의 정보를 크롤링해온 다음, 해당 데이터와 "대학원 강의 데이터베이스 추가" api를 통해 데이터베이스에 데이터를 삽입하였습니다.

**기존 방식의 문제점** : 고려대 대학원 수강신청 사이트의 강의 데이터 수정 사항을 반영할 수가 없음. 억지로 반영한다고 해도 쓰레기 데이터가 데이터베이스에 남게 됨.

**해결법** : 기존의 "대학원 강의 데이터베이스 추가" api를 삭제하였습니다. 그리고, "강의 정보 동기화" api를 추가하였습니다.

**강의 정보 동기화 api란?** : /api/admin/course-synchronization
연도와 학기를 입력하면, 해당 범위에 속하는 강의들을 고려대 대학원 수강신청 사이트와 완벽하게 동기화합니다.
응답으로 데이터베이스에서 추가된 강의 개수, 수정된 강의 개수, 삭제된 강의 개수를 반환합니다.